### PR TITLE
Fix: invalid enchantment name for arrow infinity on 1.20.6+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
-projectVersion=1.5.2
+projectVersion=1.5.3
 libsPackage=team.devblook.akropolis.libs

--- a/src/main/java/team/devblook/akropolis/util/ItemStackBuilder.java
+++ b/src/main/java/team/devblook/akropolis/util/ItemStackBuilder.java
@@ -48,7 +48,7 @@ public class ItemStackBuilder {
 		// Fix: unknown "ARROW_INFINITE" field on versions 1.20.6 or newer.
 		try {
             // 1.20.6 -> 206
-	        final byte version = Byte.parseByte(Bukkit.getMinecraftVersion().substring(2).replace("\\.", ""));
+	        final int version = Integer.parseInt(Bukkit.getMinecraftVersion().substring(2).replace("\\.", ""));
 			Field field = null;
 	        // This would correspond to check if the version is higher or equals to
 	        // 1.20.6.

--- a/src/main/java/team/devblook/akropolis/util/ItemStackBuilder.java
+++ b/src/main/java/team/devblook/akropolis/util/ItemStackBuilder.java
@@ -52,7 +52,7 @@ public class ItemStackBuilder {
 			Field field = null;
 	        // This would correspond to check if the version is higher or equals to
 	        // 1.20.6.
-	        if (versionWithDecimals >= 206) {
+	        if (version >= 206) {
 			    // Use newer field name.
 	            field = Enchantment.class.getDeclaredField("INFINITY");
 	        } else {

--- a/src/main/java/team/devblook/akropolis/util/ItemStackBuilder.java
+++ b/src/main/java/team/devblook/akropolis/util/ItemStackBuilder.java
@@ -47,15 +47,12 @@ public class ItemStackBuilder {
     static {
 		// Fix: unknown "ARROW_INFINITE" field on versions 1.20.6 or newer.
 		try {
-            // 1.20.6-R0.1-SNAPSHOT * split * 1.20.6 * substring * 20.6
-	        final String versionSplitted = Bukkit.getBukkitVersion().split("-")[0]
-	            .substring(2);
-	        // "20.6" from string, now represented as decimal. 
-	        final double versionWithDecimals = Double.parseDouble(versionSplitted);
+            // 1.20.6 -> 206
+	        final byte version = Byte.parseByte(Bukkit.getMinecraftVersion().substring(2).replace("\\.", ""));
 			Field field = null;
 	        // This would correspond to check if the version is higher or equals to
 	        // 1.20.6.
-	        if (versionWithDecimals >= 20.6) {
+	        if (versionWithDecimals >= 206) {
 			    // Use newer field name.
 	            field = Enchantment.class.getDeclaredField("INFINITY");
 	        } else {


### PR DESCRIPTION
Fixes #14 
- Fix invalid enchantment name for `ARROW_INFINITE` since the 1.20.6 version.
- Bump plugin version to `1.5.3`.